### PR TITLE
chore(rules): add rule requiring semantic PR titles

### DIFF
--- a/.cursor/rules/pull-request-title.mdc
+++ b/.cursor/rules/pull-request-title.mdc
@@ -1,0 +1,20 @@
+---
+description:
+globs:
+alwaysApply: false
+---
+# Pull Request Title Rule
+
+All pull request titles must follow [semantic commit message](mdc:https:/www.conventionalcommits.org/en/v1.0.0) rules. This ensures clarity and consistency in the project's history and automation workflows.
+
+## Requirements
+- The pull request title should be in the format: `<type>(optional scope): <description>`
+- Examples of valid types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `style`, `perf`, `ci`, etc.
+- The description should be concise and use the imperative mood.
+
+## Example
+- `feat: add setup script for environment and hooks`
+- `fix(mcp_scripts): correct token replacement logic`
+
+## Additional Notes
+- Pull requests that do not follow this rule may be rejected or require renaming before merging.


### PR DESCRIPTION
This pull request adds a Cursor rule requiring all pull request titles to follow semantic commit message conventions, improving clarity and automation for the project.